### PR TITLE
Remove jre install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update \
     g++ \
     gcc \
     git \
-    openjdk-8-jre-headless \
     curl \
     python-pip \
     python3-pip \


### PR DESCRIPTION
Since this Dockerfile is not running a Jenkins agent, installing a JRE is unnecessary.